### PR TITLE
Check edx.properties exists

### DIFF
--- a/src/main/groovy/org/edx/builder/AppPlugin.groovy
+++ b/src/main/groovy/org/edx/builder/AppPlugin.groovy
@@ -40,7 +40,10 @@ class AppPlugin implements Plugin<Project> {
     private def loadPluginConfiguration(project) {
         // first find out where the more specific properties are
         try {
-            project.apply from: project.file('edx.properties')
+            def configFile = project.file('edx.properties')
+            if (configFile.exists()) {
+                project.apply from: configFile
+            }
         }
         catch(GradleException e) {
             println "Could not load edx.properties, using default configuration"


### PR DESCRIPTION
## Description

There is an issue in plugin with latest gradle(4.10.2), It does not apply default configurations if edx.properties file is missing in project. 

Gradel Update Ticket: [LEARNER-6063](https://openedx.atlassian.net/browse/LEARNER-6063)

## How to Test

- Delete your plugin folder at **edx-app-ios/buildSrc/**
- Update last line in **build.gradle** at **edx-app-ios/buildSrc/** with `edXAppPluginSetup('https://github.com/zeshanarifios/edx-app-gradle-plugin', 'a37dae3d306a4a1610bc51b23d8ff833f9ef1261')`
- Clean and run
