### PR TITLE
chore: Replace compile with implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ repositories {
 }
 
 dependencies {
-    compile localGroovy()
-    compile gradleApi()
-    compile 'org.yaml:snakeyaml:1.14'
+    implementation localGroovy()
+    implementation gradleApi()
+    implementation 'org.yaml:snakeyaml:1.29'
 }


### PR DESCRIPTION
### Description

[LEARNER-8736](https://openedx.atlassian.net/browse/LEARNER-8736)

- Replace `compile` with `implementation` configuration for the Gradle dependencies in support of Gradle plugin `v7.0.3`.
- Bump to `org.yaml:snakeyaml` v1.29 

ref: https://bitbucket.org/snakeyaml/snakeyaml/wiki/Changes